### PR TITLE
Added changes() method.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rethinkts",
-  "version": "0.0.6",
+  "version": "0.0.8",
   "description": "A model system for RethinkDB, written in and for TypeScript.",
   "main": "js/index.js",
   "typings": "js/index",

--- a/ts/src/field.ts
+++ b/ts/src/field.ts
@@ -1,6 +1,3 @@
-/// <reference path="../../node_modules/reflect-metadata/reflect-metadata.d.ts" />
-
-import * as pluralise from "pluralize";
 import * as _ from "lodash";
 import { Model } from "./model";
 

--- a/ts/src/model.ts
+++ b/ts/src/model.ts
@@ -78,6 +78,11 @@ export class Model {
     }
     return q.run().map(res => new this(res, false));
   }
+
+  public static changes<T extends Model>(opts: ChangesOpts = {}): Promise<ChangesFeed<T>> {
+    let q = this.prototype.query().changes(opts);
+    return q.run();
+  }
   
   private static _getCollectionOptions(opts: string | CollectionOpts) {
     const options: CollectionOpts = {};
@@ -295,4 +300,21 @@ Model.prototype._pk = "id";
 export interface CollectionOpts {
   index?: string;
   predicate?: (q: any) => any;
+}
+
+export interface ChangesOpts {
+  squash?: boolean | number;
+  changefeed_queue_size?: number;
+  include_initial?: boolean;
+  include_states?: boolean;
+  include_offsets?: boolean;
+  include_types?: boolean;
+}
+
+export interface ChangesFeed<T extends Model> {
+  each: (callback: (document: {
+    old_val: T;
+    new_val: T;
+    state?: string;
+  }) => any) => any;
 }

--- a/ts/src/model.ts
+++ b/ts/src/model.ts
@@ -80,8 +80,7 @@ export class Model {
   }
 
   public static changes<T extends Model>(opts: ChangesOpts = {}): Promise<ChangesFeed<T>> {
-    let q = this.prototype.query().changes(opts);
-    return q.run();
+    return this.prototype.query().changes(opts).run();
   }
   
   private static _getCollectionOptions(opts: string | CollectionOpts) {
@@ -312,9 +311,11 @@ export interface ChangesOpts {
 }
 
 export interface ChangesFeed<T extends Model> {
-  each: (callback: (document: {
-    old_val: T;
-    new_val: T;
-    state?: string;
-  }) => any) => any;
+  each: (callback: (document: DocumentChange<T>) => any) => any;
+}
+
+export interface DocumentChange<T extends Model> {
+  old_val: T;
+  new_val: T;
+  state?: string;
 }


### PR DESCRIPTION
This allows being able to get a changefeed for the table. The Type def for the calllback are incorrect due to it not returning the model but a "document" but we don't have a clean way to return the definition of the raw model properties.
Also removed an unneeded reference for types.