### PR TITLE
Changed: Allow the setting of the table name.

### DIFF
--- a/ts/src/connection.ts
+++ b/ts/src/connection.ts
@@ -25,13 +25,13 @@ export class RethinkConnection {
         return this.models[name];
     }
 
-    public registerModel(TheModel: typeof Model, database: string = this.defaultDatabase): Promise<{ tables_created: number }> {
+    public registerModel(TheModel: typeof Model, database: string = this.defaultDatabase, opts: { table: string; } = {}): Promise<{ tables_created: number }> {
         if (!database) {
             throw new Error('No database specified');
         }
 
         const name = _.camelCase((<any>TheModel).name);
-        const table = pluralise(name);
+        const table = pluralise(opts.table || name);
 
         this.models[name] = TheModel;
 


### PR DESCRIPTION
Currently if you have more than one model named the same on one connection it will use the last added one. Changing the class name fixes this but then you have more tables created with the wrong names. Thus that this setting allows the option to set the table name that should be used.